### PR TITLE
chore(release): v1.1.0

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -47,7 +47,7 @@ jobs:
         if: matrix.platform == 'ubuntu-22.04'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.0-dev build-essential curl wget file libssl-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev
+          sudo apt-get install -y libwebkit2gtk-4.1-dev build-essential curl wget file libssl-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev
 
       - name: install frontend dependencies
         run: npm install
@@ -56,7 +56,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tagName: zats-greenscore-v${{ env.VERSION }}
+          tagName: v${{ env.VERSION }}
           releaseName: 'Zatsit Green Score v${{ env.VERSION }}'
           releaseBody: 'See the assets to download this version and install.'
           releaseDraft: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.1.0] - 2026-05-29
+
+### Added
+
+- EROOM preliminary step support via generic `PreliminaryConfig` on evaluation types (label, thresholds, blocking flag, recommendations)
+- Dedicated Quick Diagnosis card on project view, distinct from the advanced score
+- `preliminaryScore` persisted on evaluations
+
+### Changed
+
+- Separated EROOM Quick Diagnosis (category 0) from Advanced Diagnosis (categories 1-6)
+- Advanced score, interpretation and radar chart now stay hidden until at least one advanced question is answered
+- Advanced summary cards explicitly labeled "Advanced Diagnosis"
+- CC BY-SA 4.0 attribution added for EROOM data
+- README updated with badges and new information
+
 ## [1.0.0] - 2026-03-04
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zats-greenscore",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Digital footprint calculator for eco-design evaluation of digital projects",
   "private": true,
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "app"
-version = "0.1.0"
+version = "1.1.0"
 dependencies = [
  "log",
  "open",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.1.0"
+version = "1.1.0"
 description = "the zats-greenscore Tauri App"
 authors = ["Emmanuel Peru <eperu@zatsit.fr>"]
 license = "MIT License"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "zats-greenscore",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "identifier": "com.zatsit.greenscore",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Release v1.1.0

Prépare la release v1.1.0 et active la génération de binaires desktop multi-OS.

### Version bump
- `package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml` + `Cargo.lock` : `1.0.0` → `1.1.0` (Cargo était resté à `0.1.0`)

### Changelog
- Entrée `[1.1.0]` : séparation Quick / Advanced Diagnosis EROOM (#48), attribution CC BY-SA, README

### Fix workflow `release-desktop.yml`
- **Bloquant Linux** : `libwebkit2gtk-4.0-dev` → `4.1-dev` (requis par Tauri 2)
- Tag aligné sur `v${VERSION}` (cohérent avec `v1.0.0`)

### Après merge
```
gh workflow run release-desktop.yml --ref main
```
→ build macOS (Intel + Apple Silicon), Linux, Windows → release draft `v1.1.0` avec les binaires en assets.