### PR TITLE
fix(scoring): align API Green Score ranking display with official poi…

### DIFF
--- a/docs/specs/features/scoring.md
+++ b/docs/specs/features/scoring.md
@@ -43,15 +43,27 @@ function calculateScore(answers: Record<string, Answer>): number {
 
 ### Étape 3 : Attribution du ranking
 
+Le ranking A–E suit la grille officielle API Green Score, basée sur les **points bruts** (maximum atteignable : 6000 points) :
+
+| Grade | Libellé | Points bruts | Score normalisé |
+|-------|---------|--------------|-----------------|
+| A | Excellent | ≥ 6000 | 100% |
+| B | Acceptable | ≥ 3000 | 50–99% |
+| C | Average | ≥ 2000 | 33–49% |
+| D | Poor | ≥ 1000 | 17–32% |
+| E | Very Poor | < 1000 | 0–16% |
+
 ```typescript
-function getRanking(score: number): Ranking {
-  if (score >= 80) return 'A'
-  if (score >= 60) return 'B'
-  if (score >= 40) return 'C'
-  if (score >= 20) return 'D'
+function getRankingScore(points: number): Ranking {
+  if (points >= 6000) return 'A'
+  if (points >= 3000) return 'B'
+  if (points >= 2000) return 'C'
+  if (points >= 1000) return 'D'
   return 'E'
 }
 ```
+
+> **Note** : le score affiché est normalisé en pourcentage du maximum (`points / 6000 × 100`) pour plus de simplicité. La **lettre** est en revanche calculée sur les **points bruts** : un A nécessite donc le score maximum (100%).
 
 ## Distribution des points
 
@@ -118,7 +130,7 @@ Points = (1 - (x / 100)) * 100
 
 ## Implémentation
 
-Le code de scoring se trouve dans `src/utils/scoring.ts`.
+Le code de scoring se trouve dans `src/utils/apigreenscore-scoring.ts` (et `src/utils/eroom-scoring.ts` pour EROOM).
 
 ## Évolutions futures
 

--- a/src/data/doc-content.json
+++ b/src/data/doc-content.json
@@ -55,12 +55,13 @@
       "title": "Understanding Scores",
       "apiGreenScore": {
         "title": "API Green Score Rankings",
+        "note": "For simplicity, the score is normalized to a percentage of the maximum achievable score. An A corresponds to the maximum score (100%).",
         "rankings": [
-          { "grade": "A", "range": "90-100", "color": "emerald" },
-          { "grade": "B", "range": "75-89", "color": "lime" },
-          { "grade": "C", "range": "50-74", "color": "amber" },
-          { "grade": "D", "range": "25-49", "color": "orange" },
-          { "grade": "E", "range": "0-24", "color": "red" }
+          { "grade": "A", "range": "100%", "color": "emerald" },
+          { "grade": "B", "range": "50-99%", "color": "lime" },
+          { "grade": "C", "range": "33-49%", "color": "amber" },
+          { "grade": "D", "range": "17-32%", "color": "orange" },
+          { "grade": "E", "range": "0-16%", "color": "red" }
         ]
       },
       "eroom": {

--- a/src/pages/doc.astro
+++ b/src/pages/doc.astro
@@ -135,6 +135,9 @@ function parseBoldMarkup(text: string): TextPart[] {
             <div class="space-y-6">
                 <div>
                     <h3 class="font-medium mb-3">{sections.understandingScores.apiGreenScore.title}</h3>
+                    {sections.understandingScores.apiGreenScore.note && (
+                            <p class="text-sm text-muted mb-3">{sections.understandingScores.apiGreenScore.note}</p>
+                    )}
                     <div class="grid grid-cols-5 gap-2 text-center text-sm" role="list"
                          aria-label="Score rankings from A to E">
                         {sections.understandingScores.apiGreenScore.rankings.map((ranking: {
@@ -146,7 +149,7 @@ function parseBoldMarkup(text: string): TextPart[] {
                                         class={`p-2 rounded ${colorClasses[ranking.color].bg} grade-text`}
                                         style={`--grade-light: ${colorClasses[ranking.color].lightColor}; --grade-dark: ${colorClasses[ranking.color].darkColor};`}
                                         role="listitem"
-                                        aria-label={`Grade ${ranking.grade}: ${ranking.range} points`}
+                                        aria-label={`Grade ${ranking.grade}: ${ranking.range}`}
                                 >
                                     <div class="font-bold" aria-hidden="true">{ranking.grade}</div>
                                     <div class="text-xs" aria-hidden="true">{ranking.range}</div>

--- a/src/utils/ui.ts
+++ b/src/utils/ui.ts
@@ -22,19 +22,24 @@ export const getEvaluationTypeName = (type: EvaluationType): string => {
     return EVALUATION_TYPES[type]?.name || type;
 };
 
+// Ranking thresholds expressed on the displayed 0-100 score. The official API
+// Green Score grades on raw points (max 6000): A>=6000, B>=3000, C>=2000,
+// D>=1000. Since the displayed score is points/6000*100, those bands map to the
+// percentage thresholds below (A=100, B=50, C=33, D=17), keeping the badge
+// colour consistent with the letter grade.
 export const RankingResult = {
-    A: { text: ProjectRanking.A, minScore: 90, color: 'var(--color-score-excellent)', ecoLabelClass: 'text-emerald-400' },
-    B: { text: ProjectRanking.B, minScore: 75, color: 'var(--color-score-good)', ecoLabelClass: 'text-lime-400' },
-    C: { text: ProjectRanking.C, minScore: 50, color: 'var(--color-score-average)' , ecoLabelClass: 'text-amber-400' },
-    D: { text: ProjectRanking.D, minScore: 25, color: 'var(--color-score-poor)' , ecoLabelClass: 'text-orange-400' },
+    A: { text: ProjectRanking.A, minScore: 100, color: 'var(--color-score-excellent)', ecoLabelClass: 'text-emerald-400' },
+    B: { text: ProjectRanking.B, minScore: 50, color: 'var(--color-score-good)', ecoLabelClass: 'text-lime-400' },
+    C: { text: ProjectRanking.C, minScore: 33, color: 'var(--color-score-average)' , ecoLabelClass: 'text-amber-400' },
+    D: { text: ProjectRanking.D, minScore: 17, color: 'var(--color-score-poor)' , ecoLabelClass: 'text-orange-400' },
     E: { text: ProjectRanking.E, minScore: 0, color: 'var(--color-score-poor)', ecoLabelClass: 'text-red-400' }
 };
 
 export const getRanking = (score: number): typeof RankingResult[keyof typeof RankingResult] => {
-    if (score >= 90) return RankingResult.A;
-    if (score >= 75) return RankingResult.B;
-    if (score >= 50) return RankingResult.C;
-    if (score >= 25) return RankingResult.D;
+    if (score >= 100) return RankingResult.A;
+    if (score >= 50) return RankingResult.B;
+    if (score >= 33) return RankingResult.C;
+    if (score >= 17) return RankingResult.D;
     return RankingResult.E;
 }
 

--- a/tests/unit/utils/ui.test.ts
+++ b/tests/unit/utils/ui.test.ts
@@ -15,30 +15,32 @@ import { EvaluationType } from '../../../src/types/evaluation'
 // getRanking
 // ============================================================================
 
+// Thresholds mirror the official API Green Score point bands mapped onto the
+// 0-100 displayed score: A=100, B>=50, C>=33, D>=17, E<17.
 describe('getRanking', () => {
-  it('returns A for score >= 90', () => {
-    expect(getRanking(90)).toBe(RankingResult.A)
+  it('returns A only for a perfect score (100)', () => {
     expect(getRanking(100)).toBe(RankingResult.A)
+    expect(getRanking(99)).toBe(RankingResult.B)
   })
 
-  it('returns B for score >= 75 and < 90', () => {
-    expect(getRanking(75)).toBe(RankingResult.B)
-    expect(getRanking(89)).toBe(RankingResult.B)
+  it('returns B for score >= 50 and < 100', () => {
+    expect(getRanking(50)).toBe(RankingResult.B)
+    expect(getRanking(99)).toBe(RankingResult.B)
   })
 
-  it('returns C for score >= 50 and < 75', () => {
-    expect(getRanking(50)).toBe(RankingResult.C)
-    expect(getRanking(74)).toBe(RankingResult.C)
+  it('returns C for score >= 33 and < 50', () => {
+    expect(getRanking(33)).toBe(RankingResult.C)
+    expect(getRanking(49)).toBe(RankingResult.C)
   })
 
-  it('returns D for score >= 25 and < 50', () => {
-    expect(getRanking(25)).toBe(RankingResult.D)
-    expect(getRanking(49)).toBe(RankingResult.D)
+  it('returns D for score >= 17 and < 33', () => {
+    expect(getRanking(17)).toBe(RankingResult.D)
+    expect(getRanking(32)).toBe(RankingResult.D)
   })
 
-  it('returns E for score < 25', () => {
+  it('returns E for score < 17', () => {
     expect(getRanking(0)).toBe(RankingResult.E)
-    expect(getRanking(24)).toBe(RankingResult.E)
+    expect(getRanking(16)).toBe(RankingResult.E)
   })
 })
 
@@ -64,7 +66,8 @@ describe('getScoreColor', () => {
   })
 
   it('uses getRanking color for API_GREEN_SCORE', () => {
-    expect(getScoreColor(95, EvaluationType.API_GREEN_SCORE)).toBe('var(--color-score-excellent)')
+    expect(getScoreColor(100, EvaluationType.API_GREEN_SCORE)).toBe('var(--color-score-excellent)')
+    expect(getScoreColor(60, EvaluationType.API_GREEN_SCORE)).toBe('var(--color-score-good)')
     expect(getScoreColor(10, EvaluationType.API_GREEN_SCORE)).toBe('var(--color-score-poor)')
   })
 })


### PR DESCRIPTION
…nt bands

The A-E grade is computed from raw points (max 6000: A>=6000, B>=3000, C>=2000, D>=1000), but several places used inconsistent percentage thresholds, so the badge colour, the docs and the spec disagreed with the actual grade.

- ui.ts: align getRanking colour thresholds with the point bands mapped to the 0-100 score (A=100, B>=50, C>=33, D>=17) so colour matches the letter
- doc-content.json / doc.astro: correct the displayed ranges, add a note that the score is normalized to a percentage, fix the aria-label
- scoring.md: document the real point-based bands and fix a stale file path
- update getRanking/getScoreColor tests to the corrected thresholds