### PR TITLE
chore(release): v1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.1.1] - 2026-06-08
+
+### Fixed
+
+- EROOM scoring: corrected the score denominator to match the EOF reference model — partially answered categories were massively over-scored (e.g. 57% instead of 9%). Unanswered questions now count as untapped potential, and not_applicable / to_evaluate / in-progress answers are excluded from the maximum
+- API Green Score: aligned badge colour, documentation and spec with the official point-based ranking bands (the grade letter and badge colour could disagree)
+- Dashboard: removed the EROOM response counter that showed even for never-started evaluations; the EROOM score now stays hidden ("--") until the evaluation is complete; in-progress score badges are labelled by evaluation type
+- Dashboard: a project is marked "Completed" only when all of its evaluations are complete
+
+### Documentation
+
+- Corrected the EROOM data-model scoring metadata to match the verified implementation (Ease of Change mapping, global score over standard categories 1-5)
+
 ## [1.1.0] - 2026-05-29
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zats-greenscore",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Digital footprint calculator for eco-design evaluation of digital projects",
   "private": true,
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "app"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "log",
  "open",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "1.1.0"
+version = "1.1.1"
 description = "the zats-greenscore Tauri App"
 authors = ["Emmanuel Peru <eperu@zatsit.fr>"]
 license = "MIT License"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "zats-greenscore",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "identifier": "com.zatsit.greenscore",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
- bump version to 1.1.1 (package.json, tauri.conf.json, Cargo.toml/lock)
- add 1.1.1 changelog entry (EROOM scoring denominator fix, API Green Score ranking consistency, dashboard fixes)