### PR TITLE
feat(projects): add import/export of projects as JSON backup

### DIFF
--- a/src/components/WelcomeHero.astro
+++ b/src/components/WelcomeHero.astro
@@ -35,9 +35,14 @@ const evaluationTypes = getAvailableEvaluationTypes()
         </div>
 
         <!-- CTA -->
-        <a href="/projects/new" class="btn btn-primary text-base px-6 py-3 inline-block">
-            + Create your first project
-        </a>
+        <div class="flex flex-wrap gap-3 justify-center">
+            <a href="/projects/new" class="btn btn-primary text-base px-6 py-3 inline-block">
+                + Create your first project
+            </a>
+            <button id="importBtnHero" type="button" class="btn btn-secondary text-base px-6 py-3">
+                Import projects
+            </button>
+        </div>
 
         <!-- Footer links -->
         <p class="text-sm text-muted mt-8">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -41,6 +41,16 @@ const evaluationTypes = getAvailableEvaluationTypes()
             </div>
         </div>
 
+        <!-- Backup actions -->
+        <div class="flex flex-wrap gap-3 mb-8">
+            <button id="exportBtn" class="btn btn-secondary" type="button">
+                Export projects
+            </button>
+            <button id="importBtn" class="btn btn-secondary" type="button">
+                Import projects
+            </button>
+        </div>
+
         <!-- Evaluation Type Filter -->
         <div class="flex items-center gap-3 mb-8">
             <label for="evaluationTypeFilter" class="text-sm font-medium text-muted">
@@ -107,10 +117,84 @@ const evaluationTypes = getAvailableEvaluationTypes()
         </div>
     </div>
 
+    <!-- Import Modal -->
+    <div
+            id="importModal"
+            class="fixed inset-0 z-50 hidden items-center justify-center bg-black/50 backdrop-blur-sm"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="importModalTitle"
+            aria-describedby="importModalDesc"
+    >
+        <div class="glass-card max-w-md w-full mx-4 p-6" role="document">
+            <h2 id="importModalTitle" class="text-xl font-bold mb-4">Import projects</h2>
+            <p id="importModalDesc" class="text-muted mb-4">
+                Select a previously exported JSON file, or paste its content below.
+            </p>
+
+            <label for="importFile" class="block text-sm font-medium mb-2">JSON file</label>
+            <input
+                    id="importFile"
+                    type="file"
+                    accept="application/json,.json"
+                    class="form-input mb-4 w-full"
+            />
+
+            <label for="importText" class="block text-sm font-medium mb-2">Or paste JSON</label>
+            <textarea
+                    id="importText"
+                    rows="5"
+                    class="form-input w-full mb-6 font-mono text-xs"
+                    placeholder="&#123; &quot;projects&quot;: [ ... ] &#125;"
+            ></textarea>
+
+            <div class="flex gap-4 justify-end">
+                <button class="btn btn-secondary" id="cancelImportBtn" type="button">Cancel</button>
+                <button class="btn btn-primary" id="confirmImportBtn" type="button">Import</button>
+            </div>
+        </div>
+    </div>
+
+    <!-- Import Conflict Modal -->
+    <div
+            id="conflictModal"
+            class="fixed inset-0 z-50 hidden items-center justify-center bg-black/50 backdrop-blur-sm"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="conflictModalTitle"
+            aria-describedby="conflictModalDesc"
+    >
+        <div class="glass-card max-w-md w-full mx-4 p-6" role="document">
+            <h2 id="conflictModalTitle" class="text-xl font-bold mb-4">Projects already exist</h2>
+            <p id="conflictModalDesc" class="text-muted mb-2">
+                The following projects already exist (matched by name):
+            </p>
+            <ul id="conflictList" class="list-disc list-inside text-sm mb-4 text-[var(--color-text)]"></ul>
+            <p class="text-sm text-muted mb-6">
+                Do you want to overwrite them? Overwriting replaces the existing data.
+            </p>
+            <div class="flex flex-wrap gap-4 justify-end">
+                <button class="btn btn-secondary" id="cancelConflictBtn" type="button">Cancel</button>
+                <button class="btn btn-secondary" id="skipConflictBtn" type="button">Skip existing</button>
+                <button class="btn btn-primary" id="overwriteConflictBtn" type="button">Overwrite</button>
+            </div>
+        </div>
+    </div>
+
     <script>
         import {loadProjects, getEvaluationTypeName} from '../utils/ui'
-        import {deleteProject} from '../services/project-service'
+        import {deleteProject, getAllProjects} from '../services/project-service'
+        import {
+            exportAllProjects,
+            parseProjectsFile,
+            detectNameConflicts,
+            applyImport
+        } from '../services/project-transfer-service'
+        import type {ImportSummary} from '../services/project-transfer-service'
+        import {downloadTextFile, readTextFile} from '../utils/file'
+        import {showToast} from '../utils/toast'
         import {EvaluationType} from '../types/evaluation'
+        import type {Project} from '../types/project'
 
         // Get filter element
         const filterSelect = document.getElementById('evaluationTypeFilter') as HTMLSelectElement
@@ -218,6 +302,176 @@ const evaluationTypes = getAvailableEvaluationTypes()
 
         // Listen for filter changes
         filterSelect?.addEventListener('change', loadWithFilter)
+
+        // ================================================================
+        // Export / Import projects (backup & restore)
+        // ================================================================
+        const exportBtn = document.getElementById('exportBtn')
+        const importBtn = document.getElementById('importBtn')
+        const importBtnHero = document.getElementById('importBtnHero')
+
+        const importModal = document.getElementById('importModal')
+        const importFileInput = document.getElementById('importFile') as HTMLInputElement | null
+        const importTextInput = document.getElementById('importText') as HTMLTextAreaElement | null
+        const cancelImportBtn = document.getElementById('cancelImportBtn')
+        const confirmImportBtn = document.getElementById('confirmImportBtn')
+
+        const conflictModal = document.getElementById('conflictModal')
+        const conflictList = document.getElementById('conflictList')
+        const cancelConflictBtn = document.getElementById('cancelConflictBtn')
+        const skipConflictBtn = document.getElementById('skipConflictBtn')
+        const overwriteConflictBtn = document.getElementById('overwriteConflictBtn')
+
+        // Generic modal helpers (focus management + escape + tab trap)
+        const openModal = (modal: HTMLElement | null, focusTarget?: HTMLElement | null) => {
+            if (!modal) return
+            modal.dataset.trigger = (document.activeElement as HTMLElement)?.id || ''
+            modal.classList.remove('hidden')
+            modal.classList.add('flex')
+            setTimeout(() => focusTarget?.focus(), 50)
+        }
+
+        const closeModal = (modal: HTMLElement | null) => {
+            if (!modal) return
+            modal.classList.add('hidden')
+            modal.classList.remove('flex')
+            const triggerId = modal.dataset.trigger
+            if (triggerId) document.getElementById(triggerId)?.focus()
+        }
+
+        const trapFocus = (modal: HTMLElement, e: KeyboardEvent) => {
+            if (e.key !== 'Tab') return
+            const focusable = modal.querySelectorAll<HTMLElement>(
+                'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+            )
+            const first = focusable[0]
+            const last = focusable[focusable.length - 1]
+            if (e.shiftKey && document.activeElement === first) {
+                e.preventDefault()
+                last?.focus()
+            } else if (!e.shiftKey && document.activeElement === last) {
+                e.preventDefault()
+                first?.focus()
+            }
+        }
+
+        // --- Export ---
+        const handleExport = () => {
+            if (getAllProjects().length === 0) {
+                showToast('No projects to export.', 'info')
+                return
+            }
+            const date = new Date().toISOString().slice(0, 10)
+            downloadTextFile(`greenscore-projects-${date}.json`, exportAllProjects())
+            showToast('Projects exported.', 'success')
+        }
+
+        // --- Import ---
+        let pendingImport: Project[] | null = null
+
+        const openImportModal = () => {
+            if (importFileInput) importFileInput.value = ''
+            if (importTextInput) importTextInput.value = ''
+            openModal(importModal, importFileInput)
+        }
+
+        const summarize = (s: ImportSummary) => {
+            const parts: string[] = []
+            if (s.added) parts.push(`${s.added} added`)
+            if (s.overwritten) parts.push(`${s.overwritten} overwritten`)
+            if (s.skipped) parts.push(`${s.skipped} skipped`)
+            showToast(parts.length ? `Import done: ${parts.join(', ')}.` : 'Nothing imported.', 'success')
+            loadWithFilter()
+        }
+
+        const runImport = (overwrite: boolean) => {
+            if (!pendingImport) return
+            const summary = applyImport(pendingImport, overwrite)
+            pendingImport = null
+            summarize(summary)
+        }
+
+        const handleImportConfirm = async () => {
+            let content = ''
+            const file = importFileInput?.files?.[0]
+            try {
+                if (file) {
+                    content = await readTextFile(file)
+                } else if (importTextInput?.value.trim()) {
+                    content = importTextInput.value
+                } else {
+                    showToast('Select a file or paste JSON content.', 'error')
+                    return
+                }
+            } catch {
+                showToast('Failed to read the file.', 'error')
+                return
+            }
+
+            const result = parseProjectsFile(content)
+            if (!result.ok) {
+                showToast(result.error, 'error')
+                return
+            }
+
+            closeModal(importModal)
+
+            const conflicts = detectNameConflicts(result.projects, getAllProjects())
+            if (conflicts.length === 0) {
+                summarize(applyImport(result.projects, false))
+                return
+            }
+
+            // Name conflicts: ask for a single global decision before applying
+            pendingImport = result.projects
+            if (conflictList) {
+                conflictList.innerHTML = ''
+                conflicts.forEach((name) => {
+                    const li = document.createElement('li')
+                    li.textContent = name
+                    conflictList.appendChild(li)
+                })
+            }
+            openModal(conflictModal, cancelConflictBtn as HTMLElement)
+        }
+
+        // Wiring
+        exportBtn?.addEventListener('click', handleExport)
+        importBtn?.addEventListener('click', openImportModal)
+        importBtnHero?.addEventListener('click', openImportModal)
+        cancelImportBtn?.addEventListener('click', () => closeModal(importModal))
+        confirmImportBtn?.addEventListener('click', handleImportConfirm)
+        importModal?.addEventListener('click', (e) => {
+            if (e.target === importModal) closeModal(importModal)
+        })
+
+        cancelConflictBtn?.addEventListener('click', () => {
+            pendingImport = null
+            closeModal(conflictModal)
+            showToast('Import cancelled.', 'info')
+        })
+        skipConflictBtn?.addEventListener('click', () => {
+            closeModal(conflictModal)
+            runImport(false)
+        })
+        overwriteConflictBtn?.addEventListener('click', () => {
+            closeModal(conflictModal)
+            runImport(true)
+        })
+        conflictModal?.addEventListener('click', (e) => {
+            if (e.target === conflictModal) closeModal(conflictModal)
+        })
+
+        // Escape + tab trap for the backup modals
+        document.addEventListener('keydown', (e) => {
+            if (importModal?.classList.contains('flex')) {
+                if (e.key === 'Escape') closeModal(importModal)
+                else trapFocus(importModal, e)
+            } else if (conflictModal?.classList.contains('flex')) {
+                if (e.key === 'Escape') closeModal(conflictModal)
+                else trapFocus(conflictModal, e)
+            }
+        })
 
         // Initial load with default filter
         loadWithFilter()

--- a/src/services/project-service.ts
+++ b/src/services/project-service.ts
@@ -15,6 +15,7 @@ import {
     getAllProjects as storageGetAllProjects,
     getProjectById as storageGetProjectById,
     migrateStorageIfNeeded as storageMigrateIfNeeded,
+    restoreProject as storageRestoreProject,
     saveProject as storageSaveProject
 } from '../utils/storage';
 
@@ -48,6 +49,14 @@ export function getProject(id: string): Project | undefined {
  */
 export function saveProject(project: Project): void {
     storageSaveProject(project);
+}
+
+/**
+ * Restore a project verbatim (create or update), preserving its original
+ * timestamps and app version. Used when importing a backup.
+ */
+export function restoreProject(project: Project): void {
+    storageRestoreProject(project);
 }
 
 /**

--- a/src/services/project-transfer-service.ts
+++ b/src/services/project-transfer-service.ts
@@ -1,0 +1,190 @@
+/**
+ * Project Transfer Service - Export and import of projects
+ *
+ * Provides backup (export) and restore (import) of projects as JSON.
+ * Pure parsing/merge logic is kept side-effect free for testability; only
+ * exportAllProjects/applyImport touch the storage layer (via project-service).
+ *
+ * Merge strategy on import: projects are matched against existing ones by
+ * name. Name conflicts are resolved by a single global decision (overwrite
+ * all or skip all), surfaced to the user before applyImport is called.
+ */
+
+import type {Project} from '../types/project';
+import {APP_VERSION} from '../types/project';
+import {getAllProjects, restoreProject} from './project-service';
+
+export const EXPORT_FORMAT = 'zats-greenscore';
+export const EXPORT_VERSION = 1;
+
+/**
+ * Envelope wrapping exported projects with metadata for safe re-import.
+ */
+export interface ProjectsExport {
+    format: string;
+    version: number;
+    exportedAt: string;
+    appVersion: string;
+    projects: Project[];
+}
+
+export type ImportParseResult =
+    | { ok: true; projects: Project[] }
+    | { ok: false; error: string };
+
+export interface ImportSummary {
+    added: number;
+    overwritten: number;
+    skipped: number;
+}
+
+// ============================================================================
+// EXPORT
+// ============================================================================
+
+/**
+ * Serialize projects into the export envelope (pretty-printed JSON).
+ */
+export function serializeProjects(projects: Project[]): string {
+    const payload: ProjectsExport = {
+        format: EXPORT_FORMAT,
+        version: EXPORT_VERSION,
+        exportedAt: new Date().toISOString(),
+        appVersion: APP_VERSION,
+        projects
+    };
+    return JSON.stringify(payload, null, 2);
+}
+
+/**
+ * Export all stored projects as a JSON string.
+ */
+export function exportAllProjects(): string {
+    return serializeProjects(getAllProjects());
+}
+
+// ============================================================================
+// IMPORT - PARSING & VALIDATION
+// ============================================================================
+
+/**
+ * Minimal structural validation of an imported project. We only check the
+ * shape required to safely store and display it; deeper evaluation contents
+ * are tolerated to stay forward-compatible.
+ */
+function isValidProject(value: unknown): value is Project {
+    if (typeof value !== 'object' || value === null) return false;
+    const project = value as Record<string, unknown>;
+    return (
+        typeof project.id === 'string' &&
+        typeof project.name === 'string' &&
+        typeof project.description === 'string' &&
+        typeof project.createdAt === 'string' &&
+        typeof project.updatedAt === 'string' &&
+        typeof project.evaluations === 'object' &&
+        project.evaluations !== null
+    );
+}
+
+/**
+ * Parse and validate an import payload. Accepts either the export envelope
+ * ({ projects: [...] }) or a bare array of projects.
+ */
+export function parseProjectsFile(content: string): ImportParseResult {
+    const trimmed = content.trim();
+    if (!trimmed) {
+        return {ok: false, error: 'The file is empty.'};
+    }
+
+    let data: unknown;
+    try {
+        data = JSON.parse(trimmed);
+    } catch {
+        return {ok: false, error: 'Invalid JSON: the file could not be parsed.'};
+    }
+
+    let rawProjects: unknown;
+    if (Array.isArray(data)) {
+        rawProjects = data;
+    } else if (typeof data === 'object' && data !== null && 'projects' in data) {
+        rawProjects = (data as Record<string, unknown>).projects;
+    } else {
+        return {ok: false, error: 'Unrecognized format: no projects found.'};
+    }
+
+    if (!Array.isArray(rawProjects)) {
+        return {ok: false, error: 'Unrecognized format: projects must be a list.'};
+    }
+
+    const projects = rawProjects.filter(isValidProject);
+    if (projects.length === 0) {
+        return {ok: false, error: 'No valid project found in the file.'};
+    }
+
+    return {ok: true, projects};
+}
+
+// ============================================================================
+// IMPORT - MERGE
+// ============================================================================
+
+/**
+ * Return the distinct names of imported projects that already exist (by name).
+ */
+export function detectNameConflicts(
+    imported: Project[],
+    existing: Project[]
+): string[] {
+    const existingNames = new Set(existing.map((p) => p.name));
+    const conflicts = new Set<string>();
+    for (const project of imported) {
+        if (existingNames.has(project.name)) {
+            conflicts.add(project.name);
+        }
+    }
+    return [...conflicts];
+}
+
+/**
+ * Persist imported projects, merging by name.
+ *
+ * - New name: added (a fresh id is assigned if the imported id collides with
+ *   an unrelated existing project).
+ * - Existing name + overwrite=true: replaces the existing project in place
+ *   (keeps the existing id).
+ * - Existing name + overwrite=false: skipped.
+ */
+export function applyImport(
+    imported: Project[],
+    overwrite: boolean
+): ImportSummary {
+    const existing = getAllProjects();
+    const existingByName = new Map(existing.map((p) => [p.name, p]));
+    const existingIds = new Set(existing.map((p) => p.id));
+
+    const summary: ImportSummary = {added: 0, overwritten: 0, skipped: 0};
+
+    for (const project of imported) {
+        const match = existingByName.get(project.name);
+        if (match) {
+            if (overwrite) {
+                // Restore verbatim, but keep the existing id so it updates in
+                // place. Timestamps come from the backup, not import time.
+                restoreProject({...project, id: match.id});
+                summary.overwritten++;
+            } else {
+                summary.skipped++;
+            }
+            continue;
+        }
+
+        // No name conflict: avoid clobbering an unrelated project that happens
+        // to share the imported id.
+        const id = existingIds.has(project.id) ? crypto.randomUUID() : project.id;
+        restoreProject({...project, id});
+        existingIds.add(id);
+        summary.added++;
+    }
+
+    return summary;
+}

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -5,6 +5,7 @@
 import type {Evaluation} from './evaluation';
 import {EvaluationStatus, EvaluationType} from './evaluation';
 import {ProjectRanking} from './common';
+import pkg from '../../package.json';
 
 // Re-export for backward compatibility
 export {ProjectRanking} from './common';
@@ -14,10 +15,11 @@ export {ProjectRanking} from './common';
 // ============================================================================
 
 /**
- * Current application version (from package.json)
- * Used to track which version created/modified a project
+ * Current application version, read at build time from package.json
+ * (single source of truth). Used to track which version created/modified
+ * a project.
  */
-export const APP_VERSION = '0.0.1';
+export const APP_VERSION = pkg.version;
 
 /**
  * Project with support for multiple evaluation types

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -1,0 +1,35 @@
+/**
+ * Browser file helpers for downloading and reading text files.
+ * Kept DOM-focused and minimal; business logic lives in services.
+ */
+
+/**
+ * Trigger a client-side download of a text file.
+ */
+export function downloadTextFile(
+    filename: string,
+    content: string,
+    mimeType = 'application/json'
+): void {
+    const blob = new Blob([content], {type: mimeType});
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = filename;
+    document.body.appendChild(anchor);
+    anchor.click();
+    anchor.remove();
+    URL.revokeObjectURL(url);
+}
+
+/**
+ * Read a File as UTF-8 text.
+ */
+export function readTextFile(file: File): Promise<string> {
+    return new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => resolve(String(reader.result));
+        reader.onerror = () => reject(new Error('Failed to read file.'));
+        reader.readAsText(file);
+    });
+}

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -164,6 +164,26 @@ export function saveProject(project: Project): void {
 }
 
 /**
+ * Restore a project exactly as provided (create or update).
+ *
+ * Unlike saveProject, this does NOT bump updatedAt or re-stamp appVersion:
+ * it writes the project verbatim. Used by import/restore so a backup keeps
+ * its original timestamps and originating app version.
+ */
+export function restoreProject(project: Project): void {
+  const projects = getAllProjects();
+  const index = projects.findIndex((p) => p.id === project.id);
+
+  if (index >= 0) {
+    projects[index] = project;
+  } else {
+    projects.push(project);
+  }
+
+  safeSetItem(StorageKeys.PROJECTS, JSON.stringify(projects));
+}
+
+/**
  * Delete a project
  */
 export function deleteProject(id: string): void {

--- a/tests/unit/services/project-transfer-service.test.ts
+++ b/tests/unit/services/project-transfer-service.test.ts
@@ -1,0 +1,268 @@
+import {describe, it, expect, vi, beforeEach} from 'vitest'
+
+// Mock the storage module (project-transfer-service goes through project-service)
+vi.mock('../../../src/utils/storage', () => {
+  let projects: Array<Record<string, unknown>> = []
+
+  return {
+    getAllProjects: vi.fn(() => projects),
+    getProjectById: vi.fn((id: string) => projects.find(p => p.id === id)),
+    saveProject: vi.fn((project: Record<string, unknown>) => {
+      const index = projects.findIndex(p => p.id === project.id)
+      if (index >= 0) {
+        projects[index] = project
+      } else {
+        projects.push(project)
+      }
+    }),
+    restoreProject: vi.fn((project: Record<string, unknown>) => {
+      const index = projects.findIndex(p => p.id === project.id)
+      if (index >= 0) {
+        projects[index] = project
+      } else {
+        projects.push(project)
+      }
+    }),
+    deleteProject: vi.fn((id: string) => {
+      projects = projects.filter(p => p.id !== id)
+    }),
+    migrateStorageIfNeeded: vi.fn(),
+    _setProjects: (newProjects: Array<Record<string, unknown>>) => {
+      projects = [...newProjects]
+    }
+  }
+})
+
+import {
+  serializeProjects,
+  exportAllProjects,
+  parseProjectsFile,
+  detectNameConflicts,
+  applyImport,
+  EXPORT_FORMAT,
+  EXPORT_VERSION
+} from '../../../src/services/project-transfer-service'
+import type {Project} from '../../../src/types/project'
+import {APP_VERSION} from '../../../src/types/project'
+import * as storage from '../../../src/utils/storage'
+
+const makeProject = (overrides: Partial<Project> = {}): Project => ({
+  id: 'proj1',
+  name: 'Test Project',
+  description: 'Test',
+  createdAt: '2024-01-01',
+  updatedAt: '2024-01-01',
+  evaluations: {},
+  ...overrides
+})
+
+const setMockProjects = (p: unknown[]) => {
+  (storage as unknown as { _setProjects: (p: unknown[]) => void })._setProjects(p)
+}
+
+describe('project-transfer-service', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setMockProjects([])
+  })
+
+  describe('serializeProjects', () => {
+    it('wraps projects in an export envelope', () => {
+      const json = serializeProjects([makeProject()])
+      const parsed = JSON.parse(json)
+      expect(parsed.format).toBe(EXPORT_FORMAT)
+      expect(parsed.version).toBe(EXPORT_VERSION)
+      expect(parsed.exportedAt).toBeTypeOf('string')
+      expect(parsed.appVersion).toBe(APP_VERSION)
+      expect(parsed.projects).toHaveLength(1)
+      expect(parsed.projects[0].name).toBe('Test Project')
+    })
+  })
+
+  describe('exportAllProjects', () => {
+    it('serializes all stored projects', () => {
+      setMockProjects([makeProject({id: 'a'}), makeProject({id: 'b', name: 'B'})])
+      const parsed = JSON.parse(exportAllProjects())
+      expect(parsed.projects).toHaveLength(2)
+      expect(storage.getAllProjects).toHaveBeenCalled()
+    })
+  })
+
+  describe('parseProjectsFile', () => {
+    it('parses a valid export envelope', () => {
+      const json = serializeProjects([makeProject()])
+      const result = parseProjectsFile(json)
+      expect(result.ok).toBe(true)
+      if (result.ok) expect(result.projects).toHaveLength(1)
+    })
+
+    it('parses a bare array of projects', () => {
+      const json = JSON.stringify([makeProject()])
+      const result = parseProjectsFile(json)
+      expect(result.ok).toBe(true)
+      if (result.ok) expect(result.projects).toHaveLength(1)
+    })
+
+    it('rejects empty content', () => {
+      const result = parseProjectsFile('   ')
+      expect(result.ok).toBe(false)
+    })
+
+    it('rejects invalid JSON', () => {
+      const result = parseProjectsFile('{ not json')
+      expect(result.ok).toBe(false)
+    })
+
+    it('rejects an unrecognized object shape', () => {
+      const result = parseProjectsFile(JSON.stringify({foo: 'bar'}))
+      expect(result.ok).toBe(false)
+    })
+
+    it('rejects when no valid project is present', () => {
+      const result = parseProjectsFile(JSON.stringify([{id: 'x'}]))
+      expect(result.ok).toBe(false)
+    })
+
+    it('filters out malformed entries but keeps valid ones', () => {
+      const json = JSON.stringify([makeProject(), {id: 'broken'}])
+      const result = parseProjectsFile(json)
+      expect(result.ok).toBe(true)
+      if (result.ok) expect(result.projects).toHaveLength(1)
+    })
+  })
+
+  describe('detectNameConflicts', () => {
+    it('returns names present in both lists', () => {
+      const existing = [makeProject({id: 'e1', name: 'Alpha'})]
+      const imported = [
+        makeProject({id: 'i1', name: 'Alpha'}),
+        makeProject({id: 'i2', name: 'Beta'})
+      ]
+      expect(detectNameConflicts(imported, existing)).toEqual(['Alpha'])
+    })
+
+    it('returns empty when no conflicts', () => {
+      const existing = [makeProject({name: 'Alpha'})]
+      const imported = [makeProject({name: 'Beta'})]
+      expect(detectNameConflicts(imported, existing)).toEqual([])
+    })
+
+    it('deduplicates repeated conflicting names', () => {
+      const existing = [makeProject({name: 'Alpha'})]
+      const imported = [
+        makeProject({id: 'i1', name: 'Alpha'}),
+        makeProject({id: 'i2', name: 'Alpha'})
+      ]
+      expect(detectNameConflicts(imported, existing)).toEqual(['Alpha'])
+    })
+  })
+
+  describe('export then re-import (round trip)', () => {
+    it('detects name collisions when re-importing a previously exported file', () => {
+      const projects = [
+        makeProject({id: 'a', name: 'Alpha'}),
+        makeProject({id: 'b', name: 'Beta'})
+      ]
+      setMockProjects(projects)
+
+      // Export the current projects, then parse the exact same payload back.
+      const exported = exportAllProjects()
+      const parsed = parseProjectsFile(exported)
+      expect(parsed.ok).toBe(true)
+      if (!parsed.ok) return
+
+      const conflicts = detectNameConflicts(parsed.projects, storage.getAllProjects())
+      expect(conflicts.sort()).toEqual(['Alpha', 'Beta'])
+    })
+
+    it('skips everything (no duplicates) when re-importing without overwrite', () => {
+      const projects = [
+        makeProject({id: 'a', name: 'Alpha'}),
+        makeProject({id: 'b', name: 'Beta'})
+      ]
+      setMockProjects(projects)
+
+      const parsed = parseProjectsFile(exportAllProjects())
+      if (!parsed.ok) throw new Error('export should be re-importable')
+
+      const summary = applyImport(parsed.projects, false)
+      expect(summary).toEqual({added: 0, overwritten: 0, skipped: 2})
+      // Crucially: re-importing must not create duplicate projects.
+      expect(storage.getAllProjects()).toHaveLength(2)
+    })
+
+    it('overwrites in place (no duplicates) when re-importing with overwrite', () => {
+      const projects = [
+        makeProject({id: 'a', name: 'Alpha'}),
+        makeProject({id: 'b', name: 'Beta'})
+      ]
+      setMockProjects(projects)
+
+      const parsed = parseProjectsFile(exportAllProjects())
+      if (!parsed.ok) throw new Error('export should be re-importable')
+
+      const summary = applyImport(parsed.projects, true)
+      expect(summary).toEqual({added: 0, overwritten: 2, skipped: 0})
+      expect(storage.getAllProjects()).toHaveLength(2)
+    })
+
+    it('preserves original timestamps on import (does not bump updatedAt)', () => {
+      const imported = [
+        makeProject({id: 'a', name: 'Alpha', createdAt: '2024-01-01', updatedAt: '2024-03-15'})
+      ]
+      // Existing project with the same name but different dates.
+      setMockProjects([
+        makeProject({id: 'existing-a', name: 'Alpha', createdAt: '2020-01-01', updatedAt: '2020-01-01'})
+      ])
+
+      applyImport(imported, true)
+
+      const restored = storage.getAllProjects()[0] as unknown as Project
+      expect(restored.createdAt).toBe('2024-01-01')
+      expect(restored.updatedAt).toBe('2024-03-15')
+    })
+  })
+
+  describe('applyImport', () => {
+    it('adds projects with new names', () => {
+      const summary = applyImport([makeProject({id: 'new1', name: 'Fresh'})], false)
+      expect(summary).toEqual({added: 1, overwritten: 0, skipped: 0})
+      expect(storage.getAllProjects()).toHaveLength(1)
+    })
+
+    it('overwrites in place when overwrite is true (keeps existing id)', () => {
+      setMockProjects([makeProject({id: 'existing-id', name: 'Alpha', description: 'old'})])
+      const summary = applyImport(
+        [makeProject({id: 'imported-id', name: 'Alpha', description: 'new'})],
+        true
+      )
+      expect(summary).toEqual({added: 0, overwritten: 1, skipped: 0})
+      const all = storage.getAllProjects()
+      expect(all).toHaveLength(1)
+      expect(all[0].id).toBe('existing-id')
+      expect(all[0].description).toBe('new')
+    })
+
+    it('skips conflicting projects when overwrite is false', () => {
+      setMockProjects([makeProject({id: 'existing-id', name: 'Alpha', description: 'old'})])
+      const summary = applyImport(
+        [makeProject({id: 'imported-id', name: 'Alpha', description: 'new'})],
+        false
+      )
+      expect(summary).toEqual({added: 0, overwritten: 0, skipped: 1})
+      const all = storage.getAllProjects()
+      expect(all).toHaveLength(1)
+      expect(all[0].description).toBe('old')
+    })
+
+    it('assigns a new id when an imported id collides with an unrelated project', () => {
+      setMockProjects([makeProject({id: 'shared-id', name: 'Existing'})])
+      const summary = applyImport([makeProject({id: 'shared-id', name: 'Imported'})], false)
+      expect(summary).toEqual({added: 1, overwritten: 0, skipped: 0})
+      const all = storage.getAllProjects()
+      expect(all).toHaveLength(2)
+      const ids = all.map(p => p.id)
+      expect(new Set(ids).size).toBe(2)
+    })
+  })
+})

--- a/tests/unit/types/project.test.ts
+++ b/tests/unit/types/project.test.ts
@@ -4,8 +4,10 @@ import {
   hasEvaluationType,
   getHighestScore,
   getBestRanking,
-  createProject
+  createProject,
+  APP_VERSION
 } from '../../../src/types/project'
+import pkg from '../../../package.json'
 import { ProjectRanking } from '../../../src/types/common'
 import { EvaluationType, EvaluationStatus } from '../../../src/types/evaluation'
 import type { Project } from '../../../src/types/project'
@@ -158,6 +160,12 @@ describe('getBestRanking', () => {
 // ============================================================================
 // createProject
 // ============================================================================
+
+describe('APP_VERSION', () => {
+  it('derives from package.json (single source of truth)', () => {
+    expect(APP_VERSION).toBe(pkg.version)
+  })
+})
 
 describe('createProject', () => {
   it('creates a project with correct structure', () => {

--- a/tests/unit/utils/storage.test.ts
+++ b/tests/unit/utils/storage.test.ts
@@ -171,6 +171,57 @@ describe('storage', () => {
   })
 
   // ============================================================================
+  // restoreProject
+  // ============================================================================
+
+  describe('restoreProject', () => {
+    it('writes the project verbatim, preserving updatedAt', async () => {
+      localStorage.setItem('storageVersion', '2')
+      localStorage.setItem('projects', JSON.stringify([]))
+      const { restoreProject, getAllProjects } = await importStorage()
+
+      const project = {
+        id: 'restored1',
+        name: 'Backup',
+        description: 'Desc',
+        createdAt: '2024-01-01',
+        updatedAt: '2024-03-15',
+        evaluations: {},
+        appVersion: '1.0.0'
+      }
+      restoreProject(project)
+
+      const projects = getAllProjects()
+      expect(projects).toHaveLength(1)
+      // Unlike saveProject, restoreProject must not bump these.
+      expect(projects[0].updatedAt).toBe('2024-03-15')
+      expect(projects[0].createdAt).toBe('2024-01-01')
+      expect(projects[0].appVersion).toBe('1.0.0')
+    })
+
+    it('updates an existing project in place without bumping updatedAt', async () => {
+      const existing = {
+        id: 'r2',
+        name: 'Original',
+        description: 'Old',
+        createdAt: '2020-01-01',
+        updatedAt: '2020-01-01',
+        evaluations: {}
+      }
+      localStorage.setItem('storageVersion', '2')
+      localStorage.setItem('projects', JSON.stringify([existing]))
+      const { restoreProject, getAllProjects } = await importStorage()
+
+      restoreProject({ ...existing, description: 'New', updatedAt: '2024-06-01' })
+
+      const projects = getAllProjects()
+      expect(projects).toHaveLength(1)
+      expect(projects[0].description).toBe('New')
+      expect(projects[0].updatedAt).toBe('2024-06-01')
+    })
+  })
+
+  // ============================================================================
   // deleteProject
   // ============================================================================
 


### PR DESCRIPTION
- add project-transfer-service to export all/selected projects and import them back from a JSON backup file
- add file utils for download/read of JSON files
- add restoreProject in storage/service to import projects verbatim, preserving original timestamps and app version
- read APP_VERSION from package.json as single source of truth
- wire import/export actions into the home page and WelcomeHero